### PR TITLE
Changed buying and selling to eliminate sell/buy exploit and to mimic the market-making IRL

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ UOM="USD"
 DAILY_CAP = 60
 DAILY_REWARD_MIN = 15
 DAILY_REWARD_MAX = 100
-SELLING_FEE = 7  # Fee to sell stocks
+SELLING_FEE = 0  # Fee to sell stocks (@BobBeasta) Changed selling fee to $0
 REBRAND_FEE = 500 #Fee to rename stock
 
 # Dividend settings

--- a/stock_manager.py
+++ b/stock_manager.py
@@ -392,8 +392,11 @@ class StockManager:
         Returns:
             The purchase price
         """
-        # Get current price
-        price = cls.stock_prices[symbol]
+        # (@BobBeasta) Establish the random stock increase amount
+        random_increase = random.uniform(config.STOCK_BUY_MIN_CHANGE, config.STOCK_BUY_MAX_CHANGE)
+        
+        # Get current price + (@BobBeasta) half of additional
+        price = cls.stock_prices[symbol] + (random_increase / 2)
         
         # Record purchase date in user data
         from data_manager import DataManager
@@ -418,8 +421,8 @@ class StockManager:
             # Save the updated data
             DataManager.save_data(config.USER_DATA_FILE, data)
         
-        # Increase stock price after purchase (market impact)
-        change = random.uniform(config.STOCK_BUY_MIN_CHANGE, config.STOCK_BUY_MAX_CHANGE)
+        # Increase stock price after purchase (market impact) (@BobBeasta) The full random increase amount
+        change = random_increase
         new_price = cls.stock_prices[symbol] + change
         cls.stock_prices[symbol] = round(new_price, 2)
         cls.price_history[symbol].append(round(new_price, 2))
@@ -432,7 +435,7 @@ class StockManager:
     async def sell_stock(cls, symbol: str, user_id: str, bot=None) -> Tuple[float, bool, bool]:
         """
         Process a stock sale and return the sale price.
-        Applies selling fee only if stock was purchased on the same day.
+        Applies selling fee only if stock was purchased on the same day. (@BobBeasta) Made the fee equal to $0
         Also updates the stock price to reflect the sale.
         Handles bankruptcy if the price drops to 0 or below.
         
@@ -444,8 +447,11 @@ class StockManager:
         Returns:
             Tuple of (sale price, was same day sale, was bankruptcy triggered)
         """
-        # Get current price 
-        base_price = cls.stock_prices[symbol]
+        # (@BobBeasta) Establish the random stock decrease amount
+        random_decrease = random.uniform(config.STOCK_SELL_MIN_CHANGE, config.STOCK_SELL_MAX_CHANGE)
+        
+        # Get current price - (@BobBeasta) half of additional
+        base_price = cls.stock_prices[symbol] - (random_decrease / 2)
         same_day_sale = False
         fee = 0
         bankruptcy_triggered = False
@@ -475,8 +481,8 @@ class StockManager:
         # Calculate sale price after fee (if applicable)
         sale_price = base_price - fee
         
-        # Decrease stock price after sale (market impact)
-        change = random.uniform(config.STOCK_SELL_MIN_CHANGE, config.STOCK_SELL_MAX_CHANGE)
+        # Decrease stock price after sale (market impact) (@BobBeasta) The full random decrease amount
+        change = random_deacrease
         new_price = cls.stock_prices[symbol] - change
         new_price = round(new_price, 2)
         


### PR DESCRIPTION
See comment from Discord:

"An alternative solution (and perhaps more accurate) is making it so that the listed stock price (like in real life) is actually the value in between the actual sell price and the actual buy price.  So when you sell a stock that is listed at $100, you actually only get $97, and the listed price of the stock drops down to $94.  Then, if you were to purchase the stock back at the listed price of $94, you would actually pay $97, and the listed price would return to $100.

I think this option — despite being more complicated — is preferable because it is more accurate to real life (teaches you something about the stock market), fixes the exploit of sell-buying, allows for the removal of the annoying $7 fee for buy-selling (that also limits fun fast-dealing gameplay), and could be expanded into the future into a real market making system of sellers and buyers.


(numbers are all illustrative and based on the average case)"

This has been minimally implemented.